### PR TITLE
Fix for some settings are being ignored.

### DIFF
--- a/TuesPechkin/StandardConverter.cs
+++ b/TuesPechkin/StandardConverter.cs
@@ -288,13 +288,13 @@ namespace TuesPechkin
                 ? (FuncShim<string, string, int>)((k, v) => Toolset.SetGlobalSetting(config, k, v))
                 : (FuncShim<string, string, int>)((k, v) => Toolset.SetObjectSetting(config, k, v));
 
-            if (type == typeof(double?))
+            if (type == typeof(double))
             {
-                apply(name, ((double?)value).Value.ToString("0.##", CultureInfo.InvariantCulture));
+                apply(name, ((double)value).ToString("0.##", CultureInfo.InvariantCulture));
             }
-            else if (type == typeof(bool?))
+            else if (type == typeof(bool))
             {
-                apply(name, ((bool?)value).Value ? "true" : "false");
+                apply(name, ((bool)value) ? "true" : "false");
             }
             else if (typeof(IEnumerable<KeyValuePair<string, string>>).IsAssignableFrom(type))
             {


### PR DESCRIPTION
I've noticed that the `bool?` properties on the `ISettings` classes are being ignored.

The reason is that the `bool?` values passed as `object` on the `TuesPechkin.StandardConverter.Apply()` method, are being boxed to `bool` values.

This causes the expression `type == typeof(bool?)` to return false and the `else` code is executed. The `value.ToString()` method in this code block returns **True|False** instead of the expected **true|false** values.